### PR TITLE
acabar com o meu problema

### DIFF
--- a/src/flowUtils.ts
+++ b/src/flowUtils.ts
@@ -41,8 +41,10 @@ async function separeteFlows(flows: Node[]) {
 
 	for (let index = 0; index < flows.length; index++) {
 		const node = flows[index];
-		//add ordering to node
-		node.flmOrder = node.flmOrder || index;
+		if (node.type === 'tab') {
+			//add ordering to node type tab
+			node.flmOrder = node.flmOrder || index;
+		}
 		if (node.type === 'tab' || node.type === 'subflow') {
 			flowNodes.set(node.id, [node]);
 			// checkDouble({nodeId: node.id, nodeName: node.label || node.name})


### PR DESCRIPTION
Márcio, acho que ordem apenas para os flows (tab) resolve, pois os subflows não tem ordem específica por que não são abertos automaticamente... na primeira vez que fizer o deploy, vai reorganizar todas as caixinhas dentro de cada arquivo de acordo com o padrão do node-red, mas depois dessa primeira vez, dá tudo certo... testei mexendo direto no node_modules, e parece ter funcionado... 